### PR TITLE
Remove copy 'n waste damage.

### DIFF
--- a/lib/UDP.coffee
+++ b/lib/UDP.coffee
@@ -49,10 +49,3 @@ Udp = (Bridge, Url) ->
                         Bridge.send dest, path, message
 
 module.exports = Udp
-~                                                                                                                                                                                                                                           
-~                                                                                                                                                                                                                                           
-~                                                                                                                                                                                                                                           
-~                                                                                                                                                                                                                                           
-~                                                                                                                                                                                                                                           
-~                                                                                                                                                                                                                                           
-~                     


### PR DESCRIPTION
Removed, what looked to me like, copy 'n waste damage from the end of the file.

It was failing to compile with the following:

    $ coffee --compile pontifex.udp/lib/UDP.coffee
    pontifex.udp/lib/UDP.coffee:58:2: error: unexpected end of input
    ~
     ^